### PR TITLE
[BUGFIX] Re-add the static TypoScript registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Drop the dependency of `roave/security-advisories`
 
 ### Fixed
+- Re-add the static TypoScript registration (#41)
 - Keep the global namespace clean in `ext_localconf.php` (#40)
 - Update the badge URLs in the README (#29, #22)
 - Fix code inspection warnings

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,4 @@
+<?php
+defined('TYPO3_MODE') or die('Access denied.');
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('tea', 'Configuration/TypoScript', 'Tea');


### PR DESCRIPTION
The registration had accidentally been removed by some
previous changes.